### PR TITLE
修复city-picker有默认值初始化时bug

### DIFF
--- a/js/city-picker.js
+++ b/js/city-picker.js
@@ -122,6 +122,8 @@
                 }
                 if(p.value[2]) {
                     currentDistrict = p.value[2];
+                }else{
+                    currentDistrict = p.value[2] = "";
                 }
             }
             $(this).picker(p);


### PR DESCRIPTION
当city-picker初始化设置了value，并且value的长度小于cols长度时会引起picker失效，如设置value为"北京 海淀区"