### PR TITLE
将href中的协议黑名单模式改为白名单模式

### DIFF
--- a/js/router.js
+++ b/js/router.js
@@ -838,17 +838,13 @@
         var linkEle = $link.get(0);
         var linkHref = linkEle.getAttribute('href');
 
-        var protoBlackList = [
-            'tel:',
-            'javascript:' // jshint ignore:line
+        var protoWhiteList = [
+            'http',
+            'https',
         ];
 
-        if (linkHref) {
-            for (var j = protoBlackList.length - 1; j >= 0; j--) {
-                if (linkHref.indexOf(protoBlackList[j]) === 0) {
-                    return true;
-                }
-            }
+        if (/^(\w+):\/\/./.test(linkHref)) {
+            return !~protoWhiteList.indexOf(RegExp.$1)
         }
 
         //noinspection RedundantIfStatementJS


### PR DESCRIPTION
更改原有的href protocol的过滤方式，将黑名单改为白名单，只保留了http和https两个白名单协议。